### PR TITLE
Enable localization support as an argument on iOS

### DIFF
--- a/src/ios/OnFidoBridge.m
+++ b/src/ios/OnFidoBridge.m
@@ -54,7 +54,7 @@
     [configBuilder withApplicantId:applicantId];
     
     if (locale != NULL){
-        NSString * path = [[NSBundle mainBundle] pathForResource:locale ofType:@"lproj"];
+        NSString * path = [[NSBundle bundleForClass:[ONFlowConfig class]] pathForResource:locale ofType:@"lproj"];
         NSBundle * bundle = nil;
         if(path == nil){
             bundle = [NSBundle mainBundle];


### PR DESCRIPTION
The plugin as written would never find the localization strings as it was searching in the mainBundle, not the Onfido.framework bundle.